### PR TITLE
[#130515145] V3 JS integration docs update

### DIFF
--- a/source/campaigns/site_placements/invite.rst
+++ b/source/campaigns/site_placements/invite.rst
@@ -41,11 +41,10 @@ In case you need to override customer data include `customer` object in addition
 .. code-block:: html
 
   <!-- Place Talkable Container into appropriate place in the DOM -->
-  <div id="talkable-invite"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_data = {
-      // campaign_template: 'invite',
       customer: {
         email: 'overridden@example.com',
         first_name: 'OverriddenName',

--- a/source/campaigns/site_placements/post_purchase.rst
+++ b/source/campaigns/site_placements/post_purchase.rst
@@ -44,53 +44,55 @@ Below is an example with product items passed along with purchase data (notice F
 
   All product items are included into Purchase details inside Purchases report. This information is helpful for debugging.
 
-Hiding Campaign Preloader
--------------------------
-
-By default Post Purchase campaign loads with a preloader. Adding `style` attribute to `iframe` object changes its appearance:
-
-.. code-block:: html
-
-  <!-- Place Talkable Container into appropriate place in the DOM -->
-  <div id="talkable-post-purchase"></div>
-
-  <script>
-    var _talkable_data = {
-      // purchase: {
-      // ...
-      // },
-      iframe: {
-        container: 'talkable-post-purchase', // container element where to place the iframe
-        style: "display: none;" // this is just a standard inline CSS
-      }
-    };
-
-    _talkableq.push(['register_purchase', _talkable_data]);
-  </script>
-
 Embedding as Inline Widget
 --------------------------
 
-Post Purchase campaign can be also embedded as inline widget somewhere on the page. For that we only require placing the Container element into appropriate place on the site where Talkable iframe will be placed.
+Post Purchase campaign can be also embedded as inline widget somewhere on the page. For that we only require placing the Container DIV element into appropriate place on the site where Talkable iframe will be placed.
+
+Next step is to go into that Post Purchase campaign inside Talkable and:
+
+1. Visit Editor
+2. Switch into HTML/CSS editor (top right corner)
+3. Open Extra fields
+4. Enable Responsive iframe feature by pressing "On"
+5. Find Integration CSS textarea and change its CSS to position the iframe not as a popup but as inline block. Here is an example that does it:
+
+.. code-block:: scss
+
+  #{$iframe} {
+    display: block;
+    width: 100%;
+  }
+
+6. Now close Extra fields and inside HTML code area remove the following lines of code:
 
 .. code-block:: html
 
-  <!-- Place Talkable Container into appropriate place in the DOM -->
-  <div id="talkable-post-purchase"></div>
+  <div class="campaign-overlay"></div>
 
-  <script>
-    var _talkable_data = {
-      // purchase: {
-      // ...
-      // },
-      iframe: {
-        container: 'talkable-post-purchase', // container element where to place the iframe
-        style: "display: block; width: 100%;" // this is just a standard inline CSS
-      }
-    };
+And remove this DIV as well:
 
-    _talkableq.push(['register_purchase', _talkable_data]);
-  </script>
+.. code-block:: html
+
+  <div class="campaign-helper"></div>
+
+7. Inside CSS area replace this code:
+
+.. code-block:: css
+
+  body.signup,
+  body.share {
+      height: 100%;
+  }
+
+With this:
+
+.. code-block:: css
+
+  body.signup,
+  body.share {
+    overflow: hidden;
+  }
 
 Overriding Customer Data
 ------------------------
@@ -100,7 +102,7 @@ In case you need to override customer data during Purchase registration include 
 .. code-block:: html
 
   <!-- Place Talkable Container into appropriate place in the DOM -->
-  <div id="talkable-post-purchase"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_data = {

--- a/source/optional/subscribing_to_events.rst
+++ b/source/optional/subscribing_to_events.rst
@@ -11,21 +11,21 @@ Due to same-origin_ policy it is not possible to pass/get any data to the iframe
 .. _same-origin: https://en.wikipedia.org/wiki/Same-origin_policy
 .. _window.postmessage: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
 
-In order to subscribe to an iframe event you need to know `id` HTML attribute of the container that holds it, and the event name. Below is an example of subscription to `offer_loaded` Talkable iframe event.
+In order to subscribe to an iframe Event you need to know `id` HTML attribute of the Container DIV that holds it, and the Event name. Below is an example of subscription to `offer_loaded` Talkable iframe Event.
 
 Given we have integrated :ref:`invite_campaign` Talkable campaign iframe, its JS-generated HTML tag looks similar to the following:
 
 .. code-block:: html
 
-  <div id="talkable-invite">
-    <iframe name="talkable-invite" width="100%" src="https://www.talkable.com/..."></iframe>
+  <div id="talkable-offer">
+    <iframe name="talkable-offer" src="https://www.talkable.com/..."></iframe>
   </div>
 
-Knowing the container `id` attribute is `talkable-invite` the subscription JS will be:
+Knowing the container `id` attribute is `talkable-offer` the subscription JS will be:
 
 .. code-block:: javascript
 
-  talkable.subscribe("offer_loaded", "talkable-invite", function(data, iframe) {
+  talkable.subscribe("offer_loaded", "talkable-offer", function(data, iframe) {
     alert("Talkable campaign iframe is loaded!");
   });
 

--- a/source/saas.rst
+++ b/source/saas.rst
@@ -24,7 +24,7 @@ Below is an example of registering an Event and showing :ref:`post_purchase_camp
 .. code-block:: html
 
   <!-- Begin Talkable integration code -->
-  <div id="talkable-post-purchase"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_data = {
@@ -32,7 +32,7 @@ Below is an example of registering an Event and showing :ref:`post_purchase_camp
         event_number: '100011', // Required - unique Event id
         event_category: 'signups' // Required - Event category
       },
-      campaign_template: 'post-purchase' // Loads Post Purchase campaign with tag "post-purchase"
+      campaign_tags: ['post-purchase'] // Loads Post Purchase campaign with tag "post-purchase"
     };
 
     // Passing Event to Talkable
@@ -49,13 +49,13 @@ When the Event is registered successfully it appears inside Events Report. |br|
   <h2>Showing Different Campaign</h2>
 
 In the example above we show :ref:`post_purchase_campaign` Campaign as a result of Event registration.
-However you can show any other Talkable Campaign instead since there are 8 of them.
+However you can show any other Talkable Campaign instead since there are many of them.
 Here is an example how to show :ref:`invite_campaign`:
 
 .. code-block:: html
 
   <!-- Begin Talkable integration code -->
-  <div id="talkable-invite"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_data = {
@@ -63,7 +63,7 @@ Here is an example how to show :ref:`invite_campaign`:
         event_number: '100011', // Required - unique Event id
         event_category: 'signups' // Required - Event category
       },
-      campaign_template: 'invite' // Loads Invite campaign with tag "invite"
+      campaign_tags: ['invite'] // Loads Invite campaign with tag "invite"
     };
 
     // Passing Event to Talkable
@@ -72,30 +72,9 @@ Here is an example how to show :ref:`invite_campaign`:
 
 .. note::
 
-  Make sure that the Container (the DIV tag where Talkable iframe inserts to) ID corresponds to `campaign_template` value.
-  Otherwise Talkable Campaign will be shown below your page content at the very bottom.
-
-Correspondence between Container ID and `campaign_template`:
-
-+----------------------------------+---------------------------------+-----------------------------------+
-| Talkable Campaign                | Container ID                    | campaign_template                 |
-+==================================+=================================+===================================+
-| :ref:`post_purchase_campaign`    | `talkable-post-purchase`        | `post-purchase`                   |
-+----------------------------------+---------------------------------+-----------------------------------+
-| Post Purchase Full Screen Image  | `talkable-post-purchase`        | `post-purchase-full-bleed`        |
-+----------------------------------+---------------------------------+-----------------------------------+
-| :ref:`invite_campaign`           | `talkable-invite`               | `invite`                          |
-+----------------------------------+---------------------------------+-----------------------------------+
-| Invite Full Screen Image         | `talkable-invite`               | `invite-full-bleed`               |
-+----------------------------------+---------------------------------+-----------------------------------+
-| Advocate Dashboard               | `talkable-dashboard`            | `dashboard`                       |
-+----------------------------------+---------------------------------+-----------------------------------+
-| Every Visitor Popup              | `talkable-popup`                | `popup`                           |
-+----------------------------------+---------------------------------+-----------------------------------+
-| Floating Widget Popup            | `talkable-popup`                | `popup-trigger`                   |
-+----------------------------------+---------------------------------+-----------------------------------+
-| New Visitor Popup                | `talkable-popup`                | `new-visitor-popup`               |
-+----------------------------------+---------------------------------+-----------------------------------+
+  Talkable JS integration library inserts the iframe into a container DIV with id="talkable-offer".
+  Campaign Tags are show either on Campaigns listing page below each campaign's name or right on Details page
+  of any campaign, inside "Integration" area.
 
 .. raw:: html
 

--- a/source/samples/ecommerce/custom/post_purchase_basic.rst
+++ b/source/samples/ecommerce/custom/post_purchase_basic.rst
@@ -1,7 +1,7 @@
 .. code-block:: html
 
   <!-- Begin Talkable integration code -->
-  <div id="talkable-post-purchase"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_data = {
@@ -13,7 +13,7 @@
       customer: {
         email: 'customer@example.com' // Required - customer email
       },
-      campaign_template: 'post-purchase' // Loads Post Purchase campaign with tag "post-purchase"
+      campaign_tags: ['post-purchase'] // Loads Post Purchase campaign with tag "post-purchase"
     };
 
     _talkableq.push(['register_purchase', _talkable_data]); // Pass data to Talkable and show Post Purchase campaign as a result

--- a/source/samples/ecommerce/platform/shopify.rst
+++ b/source/samples/ecommerce/platform/shopify.rst
@@ -26,7 +26,7 @@
           coupon_code: checkout.discount ? checkout.discount.code : null,
           items: _talkable_order_items
         },
-        campaign_template: 'post-purchase',
+        campaign_tags: ['post-purchase'],
         customer: {
           email: checkout.email, /* REQUIRED - Customer Email Address */
           first_name: checkout.billing_address ? checkout.billing_address.first_name : null, // Optional - Customer first name

--- a/source/samples/optional/product_items.rst
+++ b/source/samples/optional/product_items.rst
@@ -1,7 +1,7 @@
 .. code-block:: html
 
   <!-- Begin Talkable integration code -->
-  <div id="talkable-post-purchase"></div>
+  <div id="talkable-offer"></div>
 
   <script>
     var _talkable_purchase_items = [];
@@ -24,7 +24,7 @@
         coupon_code: 'SAVE20', // Required - Coupon code used at checkout, multiple coupons allowed as JS array: ['SAVE20', 'FREE-SHIPPING']. Pass null if when no coupon code was used at the checkout.
         items: _talkable_purchase_items
       },
-      campaign_template: 'post-purchase' // Loads Post Purchase campaign with tag "post-purchase"
+      campaign_tags: ['post-purchase'] // Loads Post Purchase campaign with tag "post-purchase"
     };
 
     _talkableq.push(['register_purchase', _talkable_data]); // Pass data to Talkable and show Post Purchase campaign as a result

--- a/source/samples/standalone/basic.rst
+++ b/source/samples/standalone/basic.rst
@@ -1,12 +1,12 @@
 .. code-block:: html
 
   <!-- Place Talkable Container into appropriate place in the DOM -->
-  <div id="talkable-invite"></div>
+  <div id="talkable-offer"></div>
 
   <!-- Begin Talkable integration code -->
   <script>
     var _talkable_data = {
-      campaign_template: 'invite' // Loads Invite campaign with tag "invite"
+      campaign_tags: ['invite'] // Loads Invite campaign with tag "invite"
     };
 
     _talkableq.push(['register_affiliate', _talkable_data]); // Pass data to Talkable and show Invite campaign as a result


### PR DESCRIPTION
The update covers:
1. Remove ``campaign_template``, use ``campaign_tags`` instead of it.
2. Remove Container DIV -> Campaign template table of correspondence for no need
3. Rename container DIV to ``talkable-offer`` everywhere
4. Rewrite a doc for making PP campaign be placed as inline block (using Integration CSS feature)
5. Remove "Hiding Campaign Preloader" doc for no need

It does not include Site Routing yet since this feature is not live. This is an intermediate step that uses `campaign_tags` still.