### PR TITLE
[PR-7217] Update Shopify extension installation instructions

### DIFF
--- a/source/_static/talkable.css
+++ b/source/_static/talkable.css
@@ -34,20 +34,24 @@ body {
     box-sizing: border-box;
 }
 
-a {
+a, .a {
     color: #D36835;
+    cursor: pointer;
     text-decoration: none;
 }
 
 .current > a,
 a.current,
-a:hover,
-a:focus {
+a:hover {
     color: #3e4f6c;
 }
 
 abbr {
     letter-spacing: 0.08em;
+}
+
+.inline {
+    display: inline-block;
 }
 
 .button {

--- a/source/integration/shopify.rst
+++ b/source/integration/shopify.rst
@@ -4,7 +4,7 @@
 Shopify Integration
 ===================
 
-Automatic integration
+Extension integration
 ---------------------
 
   .. note::
@@ -13,22 +13,21 @@ Automatic integration
      Talkable integration script located in the Additional Content & Scripts section before
      you start the Automatic integration process. See `Manual integration`_ for details.
 
-1. Install the `Shopify Talkable application`_.
+1. Create Talkable account at |signup_link|
 
-2. In your Talkable administration panel, go to
-   **Dashboard** → Expand **Settings** dropdown → **Shopify Integration**.
+|space_indent| - Provide a valid Shopify store URL. Example: |example_link|. |br|
+|space_indent| - Choose “Shopify” as your Platform during registration process
 
-3. Then click **Install Talkable** in your Shopify administration panel.
-
-4. Modify existing integration script if needed.
-
-5. Activate Post Purchase or Invite (Standalone) Campaign.
-
-6. Verify your integration using :ref:`Verifying Integration <integration/verify>`.
+2. On the Welcome screen click "I’m Developer"
+3. Click **Install Shopify App**
+4. You will be redirected to your Shopify store, log in and click the install button
+5. After successful installation you will be redirected back to Talkable
+6. Create, set up, and Launch Campaigns (Invite, Advocate Dashboard, etc.)
+7. Verify your integration using :ref:`Verifying Integration <integration/verify>`.
 
   .. note::
 
-     Post Purchase campaign is located at the Thank you page after Checkout.
+     Post Purchase campaign is located at the “Thank you” page after Checkout.
 
      To check how Standalone Campaign looks visit */pages/share* or */pages/invite* links of your store.
      You can edit these links in Administrative panel of your store.
@@ -46,12 +45,22 @@ Manual integration
    .. include:: /samples/ecommerce/platform/shopify.rst
 
 3. Click **Apply these settings**.
-
 4. Verify your integration using :ref:`Verifying Integration <integration/verify>`.
 
 |br|
 
-.. _Shopify Talkable application: https://apps.shopify.com/talkable
+.. |signup_link| raw:: html
+
+  <a
+    href="https://talkable.com/register?object_or_array"
+    target="_blank"
+  >
+    https://talkable.com/register?object_or_array
+  </a>
+
+.. |example_link| raw:: html
+
+  <span class="a">http://123test.myshopify.com</span>
 
 .. container:: hidden
 

--- a/source/integration/shopify.rst
+++ b/source/integration/shopify.rst
@@ -16,14 +16,14 @@ Automatic integration
 1. Create Talkable account at |signup_link|
 
 |space_indent| - Provide a valid Shopify store URL. Example: |example_link|. |br|
-|space_indent| - Choose “Shopify” as your Platform during registration process
+|space_indent| - Choose “Shopify” as your platform during registration process
 
 2. On the Welcome screen click "I’m a Developer"
 3. Click **Install Shopify App**
 4. You will be redirected to your Shopify store, log in and click the install button
 5. After successful installation you will be redirected back to Talkable
-6. Create, set up, and Launch Campaigns (Invite, Advocate Dashboard, etc.)
-7. Verify your integration using :ref:`Verifying Integration <integration/verify>`.
+6. Create, set up, and launch Campaigns (Invite, Advocate Dashboard, etc.)
+7. Verify your integration using :ref:`Verifying Integration instructions <integration/verify>`.
 
   .. note::
 
@@ -45,7 +45,7 @@ Manual integration
    .. include:: /samples/ecommerce/platform/shopify.rst
 
 3. Click **Apply these settings**.
-4. Verify your integration using :ref:`Verifying Integration <integration/verify>`.
+4. Verify your integration using :ref:`Verifying Integration instructions <integration/verify>`.
 
 |br|
 
@@ -66,4 +66,4 @@ Manual integration
 
    .. toctree::
 
-      Verifying Integration Instructions <verify>
+      Verifying Integration instructions <verify>

--- a/source/integration/shopify.rst
+++ b/source/integration/shopify.rst
@@ -52,7 +52,7 @@ Manual integration
 .. |signup_link| raw:: html
 
   <a
-    href="https://talkable.com/register?object_or_array"
+    href="https://admin.talkable.com/register?object_or_array"
     target="_blank"
   >
     https://admin.talkable.com/register?object_or_array

--- a/source/integration/shopify.rst
+++ b/source/integration/shopify.rst
@@ -4,7 +4,7 @@
 Shopify Integration
 ===================
 
-Extension integration
+Automatic integration
 ---------------------
 
   .. note::
@@ -18,7 +18,7 @@ Extension integration
 |space_indent| - Provide a valid Shopify store URL. Example: |example_link|. |br|
 |space_indent| - Choose “Shopify” as your Platform during registration process
 
-2. On the Welcome screen click "I’m Developer"
+2. On the Welcome screen click "I’m a Developer"
 3. Click **Install Shopify App**
 4. You will be redirected to your Shopify store, log in and click the install button
 5. After successful installation you will be redirected back to Talkable
@@ -55,7 +55,7 @@ Manual integration
     href="https://talkable.com/register?object_or_array"
     target="_blank"
   >
-    https://talkable.com/register?object_or_array
+    https://admin.talkable.com/register?object_or_array
   </a>
 
 .. |example_link| raw:: html

--- a/source/partials/common.rst
+++ b/source/partials/common.rst
@@ -1,3 +1,11 @@
+.. |nbsp| raw:: html
+
+   &nbsp;
+
+.. |space_indent| raw:: html
+
+   <span class="inline mll"></span>
+
 .. |br| raw:: html
 
    <br>


### PR DESCRIPTION
New instructions:
![shopify integration talkable documentation 2017-08-07 13-13-53](https://user-images.githubusercontent.com/325422/29022515-4f42b316-7b72-11e7-9781-9fbcf8510bb4.png)

Demo: http://void-docs.talkable.com/integration/shopify.html#extension-integration
JIRA: PR-7217

Note: I changed the title which caused the URL to change. However, new vs old links almost do not make any difference, they both link to a relevant chapter.