### PR TITLE
Fix wrong params key at Talkable Doc

### DIFF
--- a/source/api_v2/shares.rst
+++ b/source/api_v2/shares.rst
@@ -21,7 +21,7 @@ Creates offer share.
    ================= ========================================================
    site_slug         Your Talkable Site ID. You can get this from your
                      Talkable dashboard after you log in and create a site.
-   short_url_code    Offer short code obtained with
+   offer_id          Offer short code obtained with
                      :ref:`origin creation <api_v2/origins>`.
    ================= ========================================================
 


### PR DESCRIPTION
Here is an actual param key: https://github.com/talkable/talkable/blob/8dc0cead573c116d3e80df259b44b925719530a2/app/controllers/api_v2/shares_controller.rb#L48
