### PR TITLE
[PR-9264] Write truthful doc for campaign placements criteria set up

### DIFF
--- a/source/advanced_features.rst
+++ b/source/advanced_features.rst
@@ -45,9 +45,9 @@ each with links to integration details.
      - Subscribe to Talkable Iframe events such as the campaign is loaded or closed and
        perform some updates to your site based on them.
 
-   * - :ref:`Using Regular Expressions <advanced_features/reg_ex>`
-     - Talkable allows you to use regular expressions (regex for short) inside
-       Campaign Placement options so that you can span multiple URLs instead of an exact one.
+   * - :ref:`Setting up Campaign Placement criteria <advanced_features/reg_ex>`
+     - Walking through a Campaign Placement criteria setup that can support multiple
+       matching techniques
 
    * - :ref:`Using URL Parameters <advanced_features/url_parameters>`
      - Override some of the parameters right through URL query string

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -1,58 +1,128 @@
 .. _advanced_features/reg_ex:
 .. include:: /partials/common.rst
 
-Using Regular Expressions
-=========================
+Setting up Campaign Placement criteria
+======================================
 
-Talkable allows you to use regular expressions (regex for short) inside Campaign Placement options so that you can span
-multiple URLs instead of an exact one.
-Only Talkable admins are able to use this as an option.
-In order to switch "Shown on" or "Hidden on" field into Regex mode turn on the appropriate checkbox.
-Keep in mind that you don’t need to escape **/** with backslash, those are already escaped for you.
-The rest of the queries need to be backslashed.
-It is recommended to run some checks when coding up Regex criteria: https://regex101.com.
-Here is an example of a URL: `http://www.google.com/test`, you can replace it with your site URL and add your own path(s).
+Talkable allows setting up Campaign Placement “Shown on” / “Hidden on” criteria in two
+formats:
 
-It is not recommended to hardcode your site URL like `http://site.com` because you might also support `https` protocol as
-well as `www` as a part of your domain, all combinations should work.
+1. **Relative match**. If the regex checkbox is turned **off** the relative match mode is
+   used. “Relative” means it only matches the `pathname` of a URL and query parameters,
+   without the domain part. In this mode site URL is always set and you only need to set a
+   relative path. The criteria will only trigger when the relative path is matched (and
+   query parameters when provided). Here are some examples:
 
-Examples
---------
+   * Match only the homepage:
 
-1. Show/suppress Campaigns on URLs that start with **/cart**, i.e.: `http://site.com/cart`, |br| `http://site.com/cart/checkout`,
-   but not `http://site.com/test/cart`.
+     .. code-block:: text
 
-   Here is the Regex criteria:
+       /
 
-   .. code-block:: text
+     Matched URLs (example):
 
-     https?://([\w\-\d]+\.)+[\w\-\d]+/cart
+     * `http://site.com/`
+     * `https://new.domain.com/?utm=test`
 
-2. Show/suppress Campaigns on URLs that contains **/share**, i.e.: `http://site.com/pages/share`, `http://site.com/share`,
-   `http://site.com/pages/share/product`, any URL that contains `/share`.
+     |
 
-   Here is the Regex criteria:
+   * Match “/test/deep” exact path:
 
-   .. code-block:: text
+     .. code-block:: text
 
-     /share
+       /test/deep
 
-3. Show/suppress Campaigns on multiple specific URLs, i.e.: `https://site.com/products/product-1`
-   and `https://site.com/products/product-5`.
+     Matched URLs (example):
 
-   Here is the Regex criteria:
+     * `http://site.com/test/deep`
+     * `https://new.domain.com/test/deep?utm=test`
 
-   .. code-block:: text
+     |
 
-     /products/product-1|/products/product-5
+   * Match “/test/deep?utm=true” exact path and including the requested query parameter:
 
-4. Show/suppress Campaigns only on the homepage:
+     .. code-block:: text
 
-   Here is the Regex criteria:
+       /test/deep?utm=true
 
-   .. code-block:: text
+     Matched URLs (example):
 
-     /
+     * `http://site.com/test/deep?utm=test`
+     * `https://new.domain.com/test/deep?utm=test&other=false`
+
+     |
+
+2. **Regular expression** (regex for short). If the regex checkbox is turned **on** the
+   regex mode is used. In this mode you are controlling full page URL, including the
+   domain part (unlike the relative match mode). If no query parameters set Talkable will
+   ignore query parameters of the original URL in a browser. Don’t escape with backslash,
+   the pattern is already escaped for you. See examples below:
+
+   * Match URLs that contain “/share”:
+
+     .. code-block:: text
+
+       /share
+
+     Matched URLs (example):
+
+     * `http://site.com/share`
+     * `https://new.domain.com/test/share/deep?utm=test`
+
+     |
+
+   * Match URLs containing “/share?utm=true”:
+
+     .. code-block:: text
+
+       /share?utm=true
+
+     Matched URLs (example):
+
+     * `http://site.com/share?utm=test&other=false`
+     * `https://new.domain.com/test/share?utm=test`
+
+     |
+
+   * Match only the “site.com/test” URL. No need to backslash slashes. Also, don’t include
+     protocol to match both http & https:
+
+     .. code-block:: text
+
+       site.com/test(/)?$
+
+     Matched URLs (example):
+
+     * `http://site.com/test`
+     * `https://new.domain.com/test`
+     * `http://www.site.com/test?utm=test`
+
+     |
+
+   * Match URLs that start with “/cart” (works with any domain):
+
+     .. code-block:: text
+
+       https?://([\w\-\d]+\.)+[\w\-\d]+/cart
+
+     Matched URLs (example):
+
+     * `http://site.com/cart`
+     * `http://new.domain.com/cart/deep?utm=test`
+
+     |
+
+   * Match URLs that contain either “/products/one” or “/products/two”:
+
+     .. code-block:: text
+
+       /products/one|/products/two
+
+     Matched URLs (example):
+
+     * `http://site.com/test/products/one`
+     * `http://stage.com/products/two`
+     * `http://test.com/test/products/one/deep?utm=test`
 
 .. container:: hidden
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -93,7 +93,7 @@ formats:
      Matched URLs (example):
 
      * `http://site.com/test`
-     * `https://new.domain.com/test`
+     * `https://site.com/test/`
 
      |
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -54,9 +54,11 @@ formats:
 
 2. **Regular expression** (regex for short). If the regex checkbox is turned **on** the
    regex mode is used. In this mode you are controlling full page URL, including the
-   domain part (unlike the relative match mode). If no query parameters set Talkable will
-   ignore query parameters of the original URL in a browser. Don’t escape with backslash,
-   the pattern is already escaped for you. See examples below:
+   domain part (unlike the relative match mode). If no query parameters were set Talkable
+   will ignore query parameters of the original URL in a browser.
+
+   Use https://regex101.com to test placement criteria before applying it. Note: slashes
+   are already escaped, no need to backslash them. See examples below:
 
    * Match URLs containing “/share” path with optional query parameters:
 
@@ -71,16 +73,16 @@ formats:
 
      |
 
-   * Match “/share” path containing “utm=true” query parameter:
+   * Match URLs ending with “/share” and containing “utm=true” query parameter:
 
      .. code-block:: text
 
-       /share.+utm=true
+       /share/?\?(.+)?utm=true
 
      Matched URLs (example):
 
      * `http://site.com/share?other=false&utm=true`
-     * `https://new.domain.com/test/share?utm=true`
+     * `https://new.domain.com/test/share/?utm=true&other=false`
 
      |
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -46,7 +46,13 @@ Examples
 
      /products/product-1|/products/product-5
 
-   |
+4. Show/suppress Campaigns only on the homepage:
+
+   Here is the Regex criteria:
+
+   .. code-block:: text
+
+     /
 
 .. container:: hidden
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -71,16 +71,16 @@ formats:
 
      |
 
-   * Match URLs containing “/share?utm=true”:
+   * Match “/share” path with “utm=true” query parameter:
 
      .. code-block:: text
 
-       /share.+?utm=true
+       /share.+utm=true
 
      Matched URLs (example):
 
-     * `http://site.com/share?utm=test&other=false`
-     * `https://new.domain.com/test/share?utm=test`
+     * `http://site.com/share?other=false&utm=true`
+     * `https://new.domain.com/test/share?utm=true`
 
      |
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -13,7 +13,7 @@ formats:
    relative path. The criteria will only trigger when the relative path is matched (and
    query parameters when provided). Here are some examples:
 
-   * Match only the homepage:
+   * Match only the homepage with optional query parameters:
 
      .. code-block:: text
 
@@ -26,7 +26,7 @@ formats:
 
      |
 
-   * Match “/test/deep” exact path:
+   * Match “/test/deep” exact path with optional query parameters:
 
      .. code-block:: text
 
@@ -39,7 +39,7 @@ formats:
 
      |
 
-   * Match “/test/deep?utm=true” exact path and including the requested query parameter:
+   * Match “/test/deep” exact path containing “utm=true” query parameter:
 
      .. code-block:: text
 
@@ -47,8 +47,8 @@ formats:
 
      Matched URLs (example):
 
-     * `http://site.com/test/deep?utm=test`
-     * `https://new.domain.com/test/deep?utm=test&other=false`
+     * `http://site.com/test/deep?utm=true`
+     * `https://new.domain.com/test/deep?other=false&utm=true`
 
      |
 
@@ -58,7 +58,7 @@ formats:
    ignore query parameters of the original URL in a browser. Don’t escape with backslash,
    the pattern is already escaped for you. See examples below:
 
-   * Match URLs that contain “/share”:
+   * Match URLs containing “/share” path with optional query parameters:
 
      .. code-block:: text
 
@@ -71,7 +71,7 @@ formats:
 
      |
 
-   * Match “/share” path with “utm=true” query parameter:
+   * Match “/share” path containing “utm=true” query parameter:
 
      .. code-block:: text
 
@@ -97,7 +97,7 @@ formats:
 
      |
 
-   * Match URLs that start with “/cart” (works with any domain):
+   * Match URLs starting with “/cart” path with optional query parameters:
 
      .. code-block:: text
 
@@ -110,7 +110,8 @@ formats:
 
      |
 
-   * Match URLs that contain either “/products/one” or “/products/two”:
+   * Match URLs containing either “/products/one” or “/products/two” path with optional
+     query parameters:
 
      .. code-block:: text
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -58,7 +58,10 @@ formats:
    will ignore query parameters of the original URL in a browser.
 
    Use https://regex101.com to test placement criteria before applying it. Note: slashes
-   are already escaped, no need to backslash them. See examples below:
+   are already escaped, no need to backslash them. When testing the regex criteria, change
+   delimiters to backqoutes
+   (`screenshot <https://talkable-screenshots.s3.amazonaws.com/Re_talkabletalkable-docs_PR-9264_Write_truthful_doc_for_campaign_placements_criteria_set_up_114_-_iurevychgmail.com_-_2018-06-04_15-40-09.png>`_).
+   See examples below:
 
    * Match URLs containing “/share” path with optional query parameters:
 
@@ -77,7 +80,7 @@ formats:
 
      .. code-block:: text
 
-       /share/?\?(.+)?utm=true
+       /share/?\?(.+&)?utm=true
 
      Matched URLs (example):
 
@@ -90,7 +93,7 @@ formats:
 
      .. code-block:: text
 
-       site.com/test/?$
+       site\.com/test/?$
 
      Matched URLs (example):
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -75,7 +75,7 @@ formats:
 
      .. code-block:: text
 
-       /share?utm=true
+       /share.+?utm=true
 
      Matched URLs (example):
 
@@ -84,12 +84,11 @@ formats:
 
      |
 
-   * Match only the “site.com/test” URL. No need to backslash slashes. Also, don’t include
-     protocol to match both http & https:
+   * Match “site.com/test” exact URL with any query parameters:
 
      .. code-block:: text
 
-       site.com/test(/)?$
+       site.com/test/?$
 
      Matched URLs (example):
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -4,14 +4,14 @@
 Setting up Campaign Placement criteria
 ======================================
 
-Talkable allows setting up Campaign Placement “Shown on” / “Hidden on” criteria in two
+Talkable allows setting up of Campaign Placement “Shown on” / “Hidden on” criteria in two
 formats:
 
-1. **Relative match**. If the regex checkbox is turned **off** the relative match mode is
+1. **Relative match**. If the regex checkbox is turned **off**, the relative match mode is
    used. “Relative” means it only matches the `pathname` of a URL and query parameters,
-   without the domain part. In this mode site URL is always set and you only need to set a
-   relative path. The criteria will only trigger when the relative path is matched (and
-   query parameters when provided). Here are some examples:
+   without the domain part. In this mode, the site URL is always set and you only need to
+   set a relative path. The criteria will only trigger when the relative path is matched
+   (and query parameters when provided). Here are some examples:
 
    * Match only the homepage with optional query parameters:
 
@@ -53,7 +53,7 @@ formats:
      |
 
 2. **Regular expression** (regex for short). If the regex checkbox is turned **on** the
-   regex mode is used. In this mode you are controlling full page URL, including the
+   regex mode is used. In this mode you are controlling the full page URL, including the
    domain part (unlike the relative match mode). If no query parameters were set Talkable
    will ignore query parameters of the original URL in a browser.
 

--- a/source/advanced_features/reg_ex.rst
+++ b/source/advanced_features/reg_ex.rst
@@ -84,7 +84,7 @@ formats:
 
      |
 
-   * Match “site.com/test” exact URL with any query parameters:
+   * Match “site.com/test” exact URL without any query parameters:
 
      .. code-block:: text
 
@@ -94,7 +94,6 @@ formats:
 
      * `http://site.com/test`
      * `https://new.domain.com/test`
-     * `http://www.site.com/test?utm=test`
 
      |
 


### PR DESCRIPTION
Turns out:

1.  When regex mode is off we still ignore the domain part of a URL
2. When regex mode is on you cannot escape `?` or `\` because backslash is also escaped
3. Lots of trickery with query parameters, it was unclear how they are getting matched exactly

## Demo
http://void-docs.talkable.com/advanced_features/reg_ex.html

## Related Stories
[![](http://proxies.talkable.com/talkable/PR-9264)](https://talkable.atlassian.net/browse/PR-9264)
