### PR TITLE
[PS-14487] PCP format information added

### DIFF
--- a/source/advanced_features/passing_custom_data.rst
+++ b/source/advanced_features/passing_custom_data.rst
@@ -54,6 +54,7 @@ Add the ``custom_properties`` collection to the data passed in the ``register_pu
 
     The values you pass in the ``custom_properties`` have to be JSON Key-Value pairs themselves,
     meaning that complex nested data structures can not be passed through.
+    Property names (``eye_color``) can contain lowercase letters, numbers and '_' only and cannot begin with a number
 
 .. raw:: html
 

--- a/source/advanced_features/passing_custom_data.rst
+++ b/source/advanced_features/passing_custom_data.rst
@@ -54,7 +54,7 @@ Add the ``custom_properties`` collection to the data passed in the ``register_pu
 
     The values you pass in the ``custom_properties`` have to be JSON Key-Value pairs themselves,
     meaning that complex nested data structures can not be passed through.
-    Property names (``eye_color``) can contain lowercase letters, numbers and '_' only and cannot begin with a number
+    Property names (``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number
 
 .. raw:: html
 

--- a/source/advanced_features/passing_custom_data.rst
+++ b/source/advanced_features/passing_custom_data.rst
@@ -53,7 +53,7 @@ Add the ``custom_properties`` collection to the data passed in the ``register_pu
 .. note::
 
     The values you pass in the ``custom_properties`` have to be JSON Key-Value pairs themselves,
-    meaning that complex nested data structures can not be passed through.
+    meaning that complex nested data structures cannot be passed through.
     Property names (e.g. ``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number.
 
 .. raw:: html

--- a/source/advanced_features/passing_custom_data.rst
+++ b/source/advanced_features/passing_custom_data.rst
@@ -54,7 +54,7 @@ Add the ``custom_properties`` collection to the data passed in the ``register_pu
 
     The values you pass in the ``custom_properties`` have to be JSON Key-Value pairs themselves,
     meaning that complex nested data structures can not be passed through.
-    Property names (``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number
+    Property names (``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number.
 
 .. raw:: html
 

--- a/source/advanced_features/passing_custom_data.rst
+++ b/source/advanced_features/passing_custom_data.rst
@@ -54,7 +54,7 @@ Add the ``custom_properties`` collection to the data passed in the ``register_pu
 
     The values you pass in the ``custom_properties`` have to be JSON Key-Value pairs themselves,
     meaning that complex nested data structures can not be passed through.
-    Property names (``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number.
+    Property names (e.g. ``eye_color``) can contain lowercase letters, numbers and ``_`` only and cannot begin with a number.
 
 .. raw:: html
 


### PR DESCRIPTION
I've added information about the property format needs to be used in custom properties definition. Populated from the integration error we throw when PCPs are incorrectly defined:
view-source:https://www.talkable.com/public/maxim/affiliate_members/create.html?v=4.2.6&custom_properties%5BProp%5D=11&matched_placement_ids%5B%5D=146402&ts=1574275534&ii=maxim

## Demo
<!--- Please provide a link to a demo -->
https://docs.talkable.com/advanced_features/passing_custom_data.html

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PS-14487)](https://talkable.atlassian.net/browse/PS-14487)
