### PR TITLE
[PR-15379] Extend People API 

### DIFF
--- a/source/api_v2/people.rst
+++ b/source/api_v2/people.rst
@@ -31,6 +31,60 @@ Returns a person.
 
 .. code-block:: text
 
+   GET /people/<person_slug>/referrals_as_advocate
+
+Returns referrals where person is an advocate.
+
+.. container:: ptable
+
+   ================= ========================================================
+   Parameter         Description
+   ================= ========================================================
+   site_slug         Your Talkable Site ID. You can get this from your
+                     Talkable dashboard after you log in and create a site.
+   person_slug       Person’s email or username
+   ================= ========================================================
+
+|br|
+
+.. code-block:: text
+
+   GET /people/<person_slug>/rewards
+
+Returns rewards that person has earned in referral program.
+
+.. container:: ptable
+
+   ================= ========================================================
+   Parameter         Description
+   ================= ========================================================
+   site_slug         Your Talkable Site ID. You can get this from your
+                     Talkable dashboard after you log in and create a site.
+   person_slug       Person’s email or username
+   ================= ========================================================
+
+|br|
+
+.. code-block:: text
+
+   GET /people/<person_slug>/shares_by
+
+Returns shares that person made.
+
+.. container:: ptable
+
+   ================= ========================================================
+   Parameter         Description
+   ================= ========================================================
+   site_slug         Your Talkable Site ID. You can get this from your
+                     Talkable dashboard after you log in and create a site.
+   person_slug       Person’s email or username
+   ================= ========================================================
+
+|br|
+
+.. code-block:: text
+
    PUT /people/<person_slug>
 
 Updates an existing person or creates one if it does not exist.
@@ -135,14 +189,336 @@ Sample response:
          "unsubscribed_at": null,
          "sub_choice": false,
          "customer_id": "1",
+         "custom_properties": {
+           "price_plan": "platinum"
+         },
+         "referred_by": null,
          "referral_counts": {
-           "total": 0,
-           "approved": 0,
-           "pending": 0
+           "total": 3,
+           "approved": 2,
+           "pending": 1,
+         },
+         "reward_counts": {
+           "total": 3
+           "unpaid": 1,
+           "paid": 2,
+         },
+         "share_counts": {
+           "total": 3
+           "facebook": 1,
+           "other": 2,
          }
        }
      }
    }
+
+Person referrals
+......................
+
+.. code-block:: text
+
+   GET https://www.talkable.com/api/v2/people/customer@example.com/referrals_as_advocate?site_slug=my-store
+
+Sample response:
+
+.. code-block:: javascript
+
+  {
+    "ok": true,
+    "result": {
+      "referrals": [
+        {
+          "ad_rewarded": true,
+          "advocate_person": {
+            "id": 39198,
+            "email": "customer@example.com",
+            "first_name": null,
+            "last_name": null
+          },
+          "campaign_id": 145,
+          "created_at": "2021-03-02T09:24:55.000-08:00",
+          "friend_person": {
+            "id": 39202,
+            "email": "friend@example.com",
+            "first_name": null,
+            "last_name": null
+          },
+          "id": 4,
+          "offer_id": 71,
+          "qa_generated": false,
+          "referred_origin_id": 40085,
+          "referred_subtotal": 100,
+          "status": "pending",
+          "track_method": "coupon",
+          "updated_at": "2021-03-02T09:24:55.000-08:00",
+        },
+        {
+          "ad_rewarded": true,
+          "campaign_id": 145,
+          "created_at": "2021-03-02T09:16:15.000-08:00",
+          "id": 2,
+          "offer_id": 71,
+          "qa_generated": false,
+          "referred_origin_id": 40083,
+          "referred_subtotal": 100,
+          "status": "approved",
+          "track_method": "cookie",
+          "updated_at": "2021-03-02T09:16:16.000-08:00",
+          "advocate_person": {
+            "id": 39198,
+            "email": "customer@example.com",
+            "first_name": null,
+            "last_name": null
+          },
+          "friend_person": {
+            "id": 39200,
+            "email": "john@example.com",
+            "first_name": "John",
+            "last_name": null
+          }
+        }
+      ]
+    }
+  }
+
+Person rewards
+......................
+
+.. code-block:: text
+
+   GET https://www.talkable.com/api/v2/people/customer@example.com/rewards?site_slug=my-store
+
+Sample response:
+
+.. code-block:: javascript
+
+  {
+    "ok": true,
+    "result": {
+      "rewards": [
+        {
+          "amount": 5,
+          "id": 11,
+          "reason": "referrer",
+          "status": "Unpaid",
+          "coupon": null,
+          "coupon_code": null,
+          "incentive_type": "discount_coupon",
+          "incentive_description": "shared coupon \"AD_5_OFF\" for $5 off",
+          "incentive_custom_description": null
+        },
+        {
+          "amount": 5,
+          "id": 10,
+          "reason": "referrer",
+          "status": "Paid",
+          "coupon": {
+            "description": "$5",
+            "amount": 5,
+            "code": "AD_5_OFF",
+            "expires_at": null,
+            "id": 2,
+            "percentage_discount": null,
+            "single_use": false,
+            "used": false,
+            "active": true,
+            "usages": null,
+            "valid_until": null
+          },
+          "coupon_code": "AD_5_OFF",
+          "incentive_type": "discount_coupon",
+          "incentive_description": "shared coupon \"AD_5_OFF\" for $5 off",
+          "incentive_custom_description": null
+        },
+      ]
+    }
+  }
+
+
+Person shares
+......................
+
+.. code-block:: text
+
+   GET https://www.talkable.com/api/v2/people/customer@example.com/shares_by?site_slug=my-store
+
+Sample response:
+
+.. code-block:: javascript
+
+  {
+    "ok": true,
+    "result": {
+      "shares": [
+        {
+          "short_url": "http://www.talkable.com/x/8t9d2p",
+          "channel_identifier": "facebook",
+          "id": 11,
+          "type": "SocialOfferShare",
+          "offer": {
+            "claim_url": "http://www.talkable.com/x/14PMvl",
+            "email": "test-offer@gmail.com",
+            "id": 71,
+            "short_url_code": "0EiKB3",
+            "show_url": "http://www.talkable.com/x/ArhsqM",
+            "coupon_code": null,
+            "incentives": {
+              "referrer": {
+                "action_type": "referrer",
+                "description": "$5",
+                "percentage": false,
+                "amount": 5,
+                "criteria_config": {
+                  "new_customer": true,
+                  "new_optin": false,
+                  "subtotal_min": null,
+                  "subtotal_max": null,
+                  "referrals_min": null,
+                  "referrals_max": null,
+                  "reward_uniqueness": "once_per_friend",
+                  "friend_event_category": "purchase",
+                  "has_liquid_criteria": false
+                },
+                "for_advocate": true,
+                "for_friend": false,
+                "highest_amount": true,
+                "identifier": "referrer",
+                "incentive_type": "discount_coupon",
+                "coupon_expires_at": null
+              },
+              "friend_new_customer": {
+                "action_type": "click",
+                "description": "$5",
+                "percentage": false,
+                "amount": 5,
+                "criteria_config": {
+                  "once_per_person": true,
+                  "new_customer": true,
+                  "new_optin": false,
+                  "allow_on_expired_offer": false,
+                  "allow_on_self_referral": false,
+                  "has_liquid_criteria": false
+                },
+                "for_advocate": false,
+                "for_friend": true,
+                "highest_amount": true,
+                "identifier": "friend_new_customer",
+                "incentive_type": "discount_coupon",
+                "coupon_expires_at": null
+              }
+            },
+            "trigger_widget": false,
+            "campaign_tags": [
+              "test-invite"
+            ]
+          },
+          "campaign": {
+            "slug": 145,
+            "is_active": true,
+            "appearance": "inline",
+            "id": 145,
+            "joinable_category_names": [
+              "affiliate_member"
+            ],
+            "name": "Standalone landing page",
+            "new_customer": null,
+            "origin_max_age": null,
+            "origin_min_age": null,
+            "status": "Test",
+            "tag_names": [
+              "test-invite"
+            ],
+            "type": "Standalone Campaign"
+          },
+          "friends_count": 0,
+          "friend_clicks_count": 0
+        },
+        {
+          "short_url": "http://www.talkable.com/x/14PMvl",
+          "channel_identifier": "other",
+          "id": 10,
+          "type": "SocialOfferShare",
+          "offer": {
+            "claim_url": "http://www.talkable.com/x/14PMvl",
+            "email": "test-offer@gmail.com",
+            "id": 71,
+            "short_url_code": "0EiKB3",
+            "show_url": "http://www.talkable.com/x/ArhsqM",
+            "coupon_code": null,
+            "incentives": {
+              "referrer": {
+                "action_type": "referrer",
+                "description": "$5",
+                "percentage": false,
+                "amount": 5,
+                "criteria_config": {
+                  "new_customer": true,
+                  "new_optin": false,
+                  "subtotal_min": null,
+                  "subtotal_max": null,
+                  "referrals_min": null,
+                  "referrals_max": null,
+                  "reward_uniqueness": "once_per_friend",
+                  "friend_event_category": "purchase",
+                  "has_liquid_criteria": false
+                },
+                "for_advocate": true,
+                "for_friend": false,
+                "highest_amount": true,
+                "identifier": "referrer",
+                "incentive_type": "discount_coupon",
+                "coupon_expires_at": null
+              },
+              "friend_new_customer": {
+                "action_type": "click",
+                "description": "$5",
+                "percentage": false,
+                "amount": 5,
+                "criteria_config": {
+                  "once_per_person": true,
+                  "new_customer": true,
+                  "new_optin": false,
+                  "allow_on_expired_offer": false,
+                  "allow_on_self_referral": false,
+                  "has_liquid_criteria": false
+                },
+                "for_advocate": false,
+                "for_friend": true,
+                "highest_amount": true,
+                "identifier": "friend_new_customer",
+                "incentive_type": "discount_coupon",
+                "coupon_expires_at": null
+              }
+            },
+            "trigger_widget": false,
+            "campaign_tags": [
+              "test-invite"
+            ]
+          },
+          "campaign": {
+            "slug": 145,
+            "is_active": true,
+            "appearance": "inline",
+            "id": 145,
+            "joinable_category_names": [
+              "affiliate_member"
+            ],
+            "name": "Standalone landing page",
+            "new_customer": null,
+            "origin_max_age": null,
+            "origin_min_age": null,
+            "status": "Test",
+            "tag_names": [
+              "test-invite"
+            ],
+            "type": "Standalone Campaign"
+          },
+          "friends_count": 4,
+          "friend_clicks_count": 1
+        }
+      ]
+    }
+  }
 
 Update person’s username
 ........................
@@ -182,10 +558,24 @@ Sample response:
          "unsubscribed_at": null,
          "sub_choice": false,
          "customer_id": "1",
+         "custom_properties": {
+           "price_plan": "platinum"
+         },
+         "referred_by": null,
          "referral_counts": {
-           "total": 0,
-           "approved": 0,
-           "pending": 0
+           "total": 3,
+           "approved": 2,
+           "pending": 1,
+         },
+         "reward_counts": {
+           "total": 3
+           "unpaid": 1,
+           "paid": 2,
+         },
+         "share_counts": {
+           "total": 3
+           "facebook": 1,
+           "other": 2,
          }
        }
      }
@@ -226,10 +616,24 @@ Sample response:
          "unsubscribed_at": "2014-11-18T05:49:54.000-07:00",
          "sub_choice": false,
          "customer_id": "1",
+         "custom_properties": {
+           "price_plan": "platinum"
+         },
+         "referred_by": null,
          "referral_counts": {
-           "total": 0,
-           "approved": 0,
-           "pending": 0
+           "total": 3,
+           "approved": 2,
+           "pending": 1,
+         },
+         "reward_counts": {
+           "total": 3
+           "unpaid": 1,
+           "paid": 2,
+         },
+         "share_counts": {
+           "total": 3
+           "facebook": 1,
+           "other": 2,
          }
        }
      }
@@ -270,10 +674,24 @@ Sample response:
          "unsubscribed_at": null,
          "sub_choice": false,
          "customer_id": null,
+         "custom_properties": {
+           "price_plan": "platinum"
+         },
+         "referred_by": null,
          "referral_counts": {
-           "total": 0,
-           "approved": 0,
-           "pending": 0
+           "total": 3,
+           "approved": 2,
+           "pending": 1,
+         },
+         "reward_counts": {
+           "total": 3
+           "unpaid": 1,
+           "paid": 2,
+         },
+         "share_counts": {
+           "total": 3
+           "facebook": 1,
+           "other": 2,
          }
        }
      }

--- a/source/api_v2/referrals.rst
+++ b/source/api_v2/referrals.rst
@@ -100,8 +100,20 @@ Sample response:
      "result": {
        "referral": {
          "ad_rewarded": true,
+         "advocate_person": {
+            "id": 39198,
+            "email": "customer@example.com",
+            "first_name": null,
+            "last_name": null
+          },
          "campaign_id": 196,
          "created_at": "2019-05-27T15:41:31.000-07:00",
+         "friend_person": {
+            "id": 39202,
+            "email": "friend@example.com",
+            "first_name": null,
+            "last_name": null
+          },
          "id": 233,
          "offer_id": 867,
          "qa_generated": false,

--- a/source/api_v2/shares.rst
+++ b/source/api_v2/shares.rst
@@ -77,9 +77,87 @@ Sample response:
     "ok": true,
     "result": {
       "share": {
-        "id": 4452084,
+        "short_url": "https://www.talkable.com/x/hQ0SZb",
+        "channel_identifier": "facebook",
+        "id": 10,
         "type": "SocialOfferShare",
-        "short_url": "https://www.talkable.com/x/hQ0SZb"
+        "offer": {
+          "claim_url": "http://www.talkable.com/x/14PMvl",
+          "email": "test-offer@gmail.com",
+          "id": 71,
+          "short_url_code": "0EiKB3",
+          "show_url": "http://www.talkable.com/x/ArhsqM",
+          "coupon_code": null,
+          "incentives": {
+            "referrer": {
+              "action_type": "referrer",
+              "description": "$5",
+              "percentage": false,
+              "amount": 5,
+              "criteria_config": {
+                "new_customer": true,
+                "new_optin": false,
+                "subtotal_min": null,
+                "subtotal_max": null,
+                "referrals_min": null,
+                "referrals_max": null,
+                "reward_uniqueness": "once_per_friend",
+                "friend_event_category": "purchase",
+                "has_liquid_criteria": false
+              },
+              "for_advocate": true,
+              "for_friend": false,
+              "highest_amount": true,
+              "identifier": "referrer",
+              "incentive_type": "discount_coupon",
+              "coupon_expires_at": null
+            },
+            "friend_new_customer": {
+              "action_type": "click",
+              "description": "$5",
+              "percentage": false,
+              "amount": 5,
+              "criteria_config": {
+                "once_per_person": true,
+                "new_customer": true,
+                "new_optin": false,
+                "allow_on_expired_offer": false,
+                "allow_on_self_referral": false,
+                "has_liquid_criteria": false
+              },
+              "for_advocate": false,
+              "for_friend": true,
+              "highest_amount": true,
+              "identifier": "friend_new_customer",
+              "incentive_type": "discount_coupon",
+              "coupon_expires_at": null
+            }
+          },
+          "trigger_widget": false,
+          "campaign_tags": [
+            "test-invite"
+          ]
+        },
+        "campaign": {
+          "slug": 145,
+          "is_active": true,
+          "appearance": "inline",
+          "id": 145,
+          "joinable_category_names": [
+            "affiliate_member"
+          ],
+          "name": "Standalone landing page",
+          "new_customer": null,
+          "origin_max_age": null,
+          "origin_min_age": null,
+          "status": "Test",
+          "tag_names": [
+            "test-invite"
+          ],
+          "type": "Standalone Campaign"
+        },
+        "friends_count": 4,
+        "friend_clicks_count": 1,
       },
       "reward": {
         "id": 24,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I found a few issues

- rewards
  - add target or target_id if it possible to get - as there is no way to see that
- referrals
  - add referred_origin as we do not have the ability to get origin via API - is there is a reason for that? 

WDYT?

## Demo
<!--- Please provide a link to a demo -->
http://void-docs.talkable.com/api_v2/people.html
http://void-docs.talkable.com/api_v2/shares.html
http://void-docs.talkable.com/api_v2/referrals.html

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-15379)](https://talkable.atlassian.net/browse/PR-15379)
