### PR TITLE
Update deployment script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,10 +77,21 @@ namespace :deploy do
     File.write('CNAME', domain)
     File.write('robots.txt', "User-agent: *\nDisallow: /") if disallow_robots
     sh 'git add -A'
-    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\" && #{push_command}"
+
+    deployed_successfully = true
+
+    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\" && #{push_command}" do |ok, _|
+      deployed_successfully = ok
+    end
+
     sh "git checkout #{source_branch}"
 
-    puts "\nDeployment finished. Check updated docs at https://#{domain}"
+    if deployed_successfully
+      puts "\nDeployment finished. Check updated docs at https://#{domain}"
+    else
+      puts "\nDeployment failed."
+      puts "\nMake sure you ran `rake setup`." if source_branch == 'void'
+    end
   end
 
   task :production do

--- a/Rakefile
+++ b/Rakefile
@@ -78,10 +78,18 @@ namespace :deploy do
     File.write('robots.txt', "User-agent: *\nDisallow: /") if disallow_robots
     sh 'git add -A'
 
+    committed = true
+    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\"" do |ok, _|
+      # `git commit` returns a non-zero code if there were no changes to commit
+      committed = ok
+    end
+
     deployed_successfully = true
 
-    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\" && #{push_command}" do |ok, _|
-      deployed_successfully = ok
+    if committed
+      sh push_command do |ok, _|
+        deployed_successfully = ok
+      end
     end
 
     sh "git checkout #{source_branch}"

--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,8 @@ namespace :deploy do
     File.write('CNAME', domain)
     File.write('robots.txt', "User-agent: *\nDisallow: /") if disallow_robots
     sh 'git add -A'
-    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\" && #{push_command} ; git checkout #{source_branch}"
+    sh "git commit -m \"Generated gh-pages for `git log #{source_branch} -1 --pretty=short --abbrev-commit`\" && #{push_command}"
+    sh "git checkout #{source_branch}"
 
     puts "\nDeployment finished. Check updated docs at https://#{domain}"
   end


### PR DESCRIPTION
Currently, `rake deploy:staging` produces no errors if you haven't run `rake setup` before deploying, despite the deployment not happening.
