### PR TITLE
[PR-23545][SEO] Canonical URLs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'mkmf'
 SPHINX_BUILD = ENV['SPHINX_BUILD'] || 'sphinx-build'
 SOURCE_DIR   = 'source'
 BUILD_DIR    = 'build'
-SPHINX_OPTS  = "-b html -d #{BUILD_DIR}/doctrees #{SOURCE_DIR} #{BUILD_DIR}/html"
+SPHINX_OPTS  = "-b dirhtml -d #{BUILD_DIR}/doctrees #{SOURCE_DIR} #{BUILD_DIR}/html"
 
 task :default => :help
 task :help do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
changed build script, so during the process sphinx will create sub dir's for files to prevent extensions show into URLs,
example: https:docs.talkable.com/index.html => https:docs.talkable.com/
Sitemap changed dynamically.

## Demo link
https://void-docs.talkable.com/

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-23545)](https://talkable.atlassian.net/browse/PR-23545)
