### PR TITLE
[PR-23881] add 404 page to docs and exclude it from sitemap

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -97,7 +97,7 @@ deploy_docs() {
     git pull origin
     docker-compose ls
     docker ps
-    docker-compose up -d --build --remove-orphans
+    docker-compose up -d --build --remove-orphans --force-recreate
 EOF
 }
 

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,10 +1,13 @@
+server_tokens off;
+
 server {
     listen 80;
     server_name _;
 
     root /var/www/html; 
     index index.html;
-
+    error_page 404 =404 /404/;
+    
     # Basic security headers
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options "nosniff";

--- a/source/404.rst
+++ b/source/404.rst
@@ -1,0 +1,16 @@
+:orphan:
+:no-search:
+
+.. include:: /partials/common.rst
+
+.. meta::
+   :description: Page not found
+
+Oops!
+=====
+
+.. raw:: html
+
+   <h2>The page you're looking for can't be found.</h2>
+
+It might have been moved or never existed.

--- a/source/conf.py
+++ b/source/conf.py
@@ -223,3 +223,8 @@ man_pages = [(master_doc, "talkable", "Talkable Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
+
+sitemap_excludes = [
+    "search/",
+    "404/",
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Changelog:**

1. 404 page
    The 404 sphinx page introduced to replace the default nginx error page
     You can check it:
      - in browser https://docs.bastion.talkable.com/sdcrdv
      - in terminal `curl -I https://docs.bastion.talkable.com/sdcrdv`
2. Sitemap
    `404` and `search` pages are excluded from the sitemap file
     Check it here https://docs.bastion.talkable.com/sitemap.xml
3. Force recreate the containers during deployment
    Due to nginx didn't load the updated config I've added `--force-recreate` parameter to the deployment command


## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-23881)](https://talkable.atlassian.net/browse/PR-23881)
