### PR TITLE
[PR-24147] /advanced_features/traffic_source/ wrong redirect

### DIFF
--- a/.cursor/rules/about.mdc
+++ b/.cursor/rules/about.mdc
@@ -3,7 +3,7 @@ description: About the project, tech stack and repository structure
 globs: 
 alwaysApply: true
 ---
-## Abour Project
+## About Project
 
 This is the official documentation for Talkable's capabilities, publicly available at docs.talkable.com.
 

--- a/nginx/redirects.conf
+++ b/nginx/redirects.conf
@@ -1,5 +1,5 @@
 rewrite ^/advanced_features/product_sku/?$ /advanced_features/product_items/ permanent;
-rewrite ^/advanced_features/traffic_source/?$ /integration/standard_integration/integration_components/ permanent;
+rewrite ^/advanced_features/traffic_source/?$ /integration/standard/integration_components/ permanent;
 rewrite ^/advanced_features/rybbon/?$ /advanced_features/bhnrewards/ permanent;
 rewrite ^/android_sdk/deep_linking/?$ /android_sdk/custom_deep_linking/ permanent;
 rewrite ^/api_v2/(campaigns|coupons|refunds|traffic_sources|visitors)/?$ /api_v2/intro/ permanent;


### PR DESCRIPTION
## Changes Made
1. Fixed typo in `.cursor/rules/about.mdc`:
   - Corrected "Abour Project" to "About Project" in the documentation header

2. Updated redirect path in `nginx/redirects.conf`:
   - Modified traffic source redirect path from `/integration/standard_integration/` to `/integration/standard/`

## Impact
- Documentation rules header is now correctly spelled
- Traffic source redirect will now point to the correct URL path, ensuring users are properly redirected when accessing the legacy traffic source documentation

## Testing Instructions
1. Documentation Header:
   - No ways to test it. The file is Cusrsor Editor system file

2. Traffic Source Redirect:
   - Try accessing the legacy URL: `/advanced_features/traffic_source/`
   - Verify you are redirected to `/integration/standard/integration_components/`
   - Ensure no 404 errors occur during the redirect

## Additional Notes
These changes are primarily maintenance updates to improve documentation accuracy and ensure proper URL redirections. No functional code changes are included in this PR.

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-24147)](https://talkable.atlassian.net/browse/PR-24147)
