### PR TITLE
Adjust-the-tag-server-to-talkable-server

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -11,7 +11,7 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'http://gtm.talkable.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'https://gtm.talkable.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-5GPVQZ3X');</script>
 <!-- End Google Tag Manager -->
 {% endblock %}
@@ -19,7 +19,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {# Google Tag Manager - Body (noscript fallback) - Using relbar1 for optimal placement #}
 {% block relbar1 %}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="http://gtm.talkable.com/ns.html?id=GTM-5GPVQZ3X"
+<noscript><iframe src="https://gtm.talkable.com/ns.html?id=GTM-5GPVQZ3X"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {{ super() }}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -11,7 +11,7 @@
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+'http://gtm.talkable.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-5GPVQZ3X');</script>
 <!-- End Google Tag Manager -->
 {% endblock %}
@@ -19,7 +19,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 {# Google Tag Manager - Body (noscript fallback) - Using relbar1 for optimal placement #}
 {% block relbar1 %}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5GPVQZ3X"
+<noscript><iframe src="http://gtm.talkable.com/ns.html?id=GTM-5GPVQZ3X"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {{ super() }}


### PR DESCRIPTION
# Update Google Tag Manager URLs to use Talkable domain

## Changes
- Updated GTM script source from `googletagmanager.com` to `gtm.talkable.com`
- Updated GTM noscript iframe source to use Talkable domain
- Maintained existing GTM container ID (GTM-5GPVQZ3X)

## Technical Details
- Modified `source/_templates/layout.html` to use custom domain for GTM tracking
- Changes affect both the main GTM script and the noscript fallback implementation
- All URLs are using HTTPS for secure communication

## Testing
- [ ] Verify GTM tracking is working correctly with the new domain
- [ ] Confirm GTM container loads properly in both JavaScript and non-JavaScript environments
- [ ] Test across different browsers to ensure consistent behavior

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-24739)](https://talkable.atlassian.net/browse/PR-24739)
